### PR TITLE
Return container information at _etcvault key

### DIFF
--- a/container/basic.go
+++ b/container/basic.go
@@ -7,7 +7,7 @@ import (
 
 type Basic struct {
 	Version string
-	Content string
+	Content string `json:"-"`
 }
 
 func ParseBasic(str string) (*Basic, error) {

--- a/container/plain1.go
+++ b/container/plain1.go
@@ -7,7 +7,7 @@ import (
 
 type Plain1 struct {
 	KeyName string
-	Content string
+	Content string `json:"-"`
 }
 
 func ParsePlain1(str string) (*Plain1, error) {

--- a/container/v1.go
+++ b/container/v1.go
@@ -8,8 +8,8 @@ import (
 
 type V1 struct {
 	KeyName    string
-	ContentKey []byte
-	Content    []byte
+	ContentKey []byte `json:"-"`
+	Content    []byte `json:"-"`
 }
 
 func ParseV1(str string) (*V1, error) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -35,23 +35,32 @@ func (engine *Engine) GetKeychain() *keys.Keychain {
 }
 
 func (engine *Engine) Transform(text string) (string, error) {
+	s, _, e := engine.TransformAndParse(text)
+	return s, e
+}
+
+func (engine *Engine) TransformAndParse(text string) (string, container.Container, error) {
+	// FIXME: test for this
 	rawContainer, err := container.Parse(text)
 
 	if err != nil {
 		if err == container.ErrInvalid {
-			return text, nil
+			return text, nil, nil
 		} else {
-			return "", err
+			return "", nil, err
 		}
 	}
 
 	switch c := rawContainer.(type) {
 	case *container.Plain1:
-		return engine.TransformPlain1(c)
+		result, err := engine.TransformPlain1(c)
+		return result, c, err
 	case *container.Asis:
-		return engine.TransformAsis(c)
+		result, err := engine.TransformAsis(c)
+		return result, c, err
 	case *container.V1:
-		return engine.TransformV1(c)
+		result, err := engine.TransformV1(c)
+		return result, c, err
 	}
 	// shouldnt reach
 	panic(fmt.Errorf("BUG: unsupported container type %#v", rawContainer))

--- a/engine/json.go
+++ b/engine/json.go
@@ -38,9 +38,15 @@ func (engine *Engine) transformEtcdJsonResponse0(nodePtr *map[string]interface{}
 
 	if value, ok := node["value"]; ok {
 		if str, ok := value.(string); ok {
-			newValue, err := engine.Transform(str)
+			newValue, container, err := engine.TransformAndParse(str)
 			if err == nil {
 				node["value"] = newValue
+				if container != nil {
+					node["_etcvault"] = map[string]interface{}{
+						"version":   container.Version(),
+						"container": container,
+					}
+				}
 			} else {
 				node["_etcvault_error"] = err.Error()
 			}

--- a/engine/json_test.go
+++ b/engine/json_test.go
@@ -12,34 +12,39 @@ func TestTransformEtcdJsonResponse(t *testing.T) {
 		Expect []byte
 	}{
 		{
+			Name:   "non-container (node.value)",
+			Case:   []byte(`{"node": {"value": "non-container"}}`),
+			Expect: []byte(`{"node":{"value":"non-container"}}`),
+		},
+		{
 			Name:   "plain (node.value)",
 			Case:   []byte(`{"node": {"value": "ETCVAULT::asis:plain::ETCVAULT"}}`),
-			Expect: []byte(`{"node":{"value":"plain"}}`),
+			Expect: []byte(`{"node":{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"}}`),
 		},
 		{
 			Name:   "plain (prevNode.value)",
 			Case:   []byte(`{"prevNode": {"value": "ETCVAULT::asis:plain::ETCVAULT"}}`),
-			Expect: []byte(`{"prevNode":{"value":"plain"}}`),
+			Expect: []byte(`{"prevNode":{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"}}`),
 		},
 		{
 			Name:   "both (node.value, prevNode.value)",
 			Case:   []byte(`{"node": {"value": "ETCVAULT::asis:plain::ETCVAULT"}, "prevNode": {"value": "ETCVAULT::asis:plain::ETCVAULT"}}`),
-			Expect: []byte(`{"node":{"value":"plain"},"prevNode":{"value":"plain"}}`),
+			Expect: []byte(`{"node":{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"},"prevNode":{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"}}`),
 		},
 		{
 			Name:   "inside directory (node.nodes[0].value)",
 			Case:   []byte(`{"node": {"nodes": [{"value": "ETCVAULT::asis:plain::ETCVAULT"}]}}`),
-			Expect: []byte(`{"node":{"nodes":[{"value":"plain"}]}}`),
+			Expect: []byte(`{"node":{"nodes":[{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"}]}}`),
 		},
 		{
 			Name:   "inside directory, multiple (node.nodes[0].value, node.nodes[1].value)",
 			Case:   []byte(`{"node": {"nodes": [{"value": "ETCVAULT::asis:plain::ETCVAULT"}, {"value": "ETCVAULT::asis:plain::ETCVAULT"}]}}`),
-			Expect: []byte(`{"node":{"nodes":[{"value":"plain"},{"value":"plain"}]}}`),
+			Expect: []byte(`{"node":{"nodes":[{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"},{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"}]}}`),
 		},
 		{
 			Name:   "nested, inside directory (node.nodes[0].nodes[0].value)",
 			Case:   []byte(`{"node": {"nodes": [{"nodes": [{"value": "ETCVAULT::asis:plain::ETCVAULT"}]}]}}`),
-			Expect: []byte(`{"node":{"nodes":[{"nodes":[{"value":"plain"}]}]}}`),
+			Expect: []byte(`{"node":{"nodes":[{"nodes":[{"_etcvault":{"container":{"Content":"plain"},"version":"asis"},"value":"plain"}]}]}}`),
 		},
 	}
 


### PR DESCRIPTION
- `container/*.go`: Add json tag to not export original content, expect asis container (it's for test).
- `engine/engine.go`: Rename func `engine.Transform` to `engine.TransformAndParse` and make it to return parsed `container.Container` additionally. And wrapped it with `engine.Transform()` for compatibility.
  
  **FIXME:** no tests for engine.TransformAndParse but exists for engine.Transform
